### PR TITLE
Force tlmgr to download continuously

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -113,7 +113,7 @@ Im Terminal:
 ```
 $ cd ~/.local
 $ curl -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz | tar xz
-$ TEXLIVE_INSTALL_PREFIX=~/.local/texlive ./install-tl-*/install-tl
+$ TEXLIVE_INSTALL_PREFIX=~/.local/texlive ./install-tl-*/install-tl --persistent-downloads
 ```
 
 Die Installition startet man mit `I` und `Enter`.

--- a/install/windows.md
+++ b/install/windows.md
@@ -713,7 +713,7 @@ cd ~/.local
 curl -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz | tar xz
 ```
 ```
-TEXLIVE_INSTALL_PREFIX=$HOME/.local/texlive ./install-tl-*/install-tl
+TEXLIVE_INSTALL_PREFIX=$HOME/.local/texlive ./install-tl-*/install-tl --persistent-downloads
 ```
 
 Der erste Befehl ändert den aktuellen Pfad auf den Ordner in den TeXLive installiert werden soll. 


### PR DESCRIPTION
This option seems to speed up the texlive installation, since it forces install-tl to do one continuous download. According to the man pages http://texdoc.net/texmf-dist/doc/man/man1/tlmgr.man1.pdf this should be the default behaviour (if I read it correctly), but I can still see a significant difference in speed.
