### PR TITLE
wie erwartet, kam noch eine neue Anaconda-Version

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -21,7 +21,7 @@ Falls man nur am LaTeX-Kurs teilnehmen will, sollte man mindestens Sumatra und A
   <div class="col-md-2" align="center"></div>
   <div class="col-md-4" align="center">
   <a href="#update" class="btn btn-secondary btn-lg btn-block" role="button">
-  Aktualisieren 
+  Aktualisieren
   </a>
   </div>
   <div class="col-md-1" align="center"></div>
@@ -62,7 +62,7 @@ Lizenz und enthalten Tracking Software. Deswegen nutzen wir VSCodium.
   Ladet die Datei `vscodium_<VERSION>_amd64.deb` von <https://github.com/VSCodium/vscodium/releases> herunter und öffnet sie mit
   dem Software Center (Doppelklick auf den Download). Klickt auf `Installieren`
 
-- Fedora 
+- Fedora
 
   Ladet die Datei `vscodium_<VERSION>_el7.x86_64.rpm` von <https://github.com/VSCodium/vscodium/releases> herunter und öffnet sie mit
   dem Software Center (Doppelklick auf den Download). Klickt auf `Installieren`.
@@ -83,7 +83,7 @@ __Wichtig__: Wir wollen Python 3.7 für Linux.
 Im Terminal im Ordner mit der heruntergeladenen Datei den Befehl:
 
 ```
-$ bash Anaconda3-2019.03-Linux-x86_64.sh -p ~/.local/anaconda3 -b
+$ bash Anaconda3-2019.07-Linux-x86_64.sh -p ~/.local/anaconda3 -b
 ```
 
 ausführen. Wenn es eine neue Version von Anaconda gibt, ändert sich der Dateiname und muss entsprechend angepasst werden.
@@ -208,7 +208,7 @@ Es sollte die Biber-Hilfe erscheinen.
 
 Es sollte die Dokumentation von TeXLive geöffnet werden (in einem PDF-Betrachter).
 
-### TeXLive einstellen: 
+### TeXLive einstellen:
 
 Im Terminal:
 

--- a/install/macos.md
+++ b/install/macos.md
@@ -54,7 +54,7 @@ Danach "Installieren" auswählen und warten. Der Download wiegt etwa 130MB.
 - [Anaconda](https://www.anaconda.com/download/#macos): Python und
   Bibliotheken
 
-__Wichtig__: Wir wollen Python 3.6 Graphical Installer (oben).  Das Paket installieren.
+__Wichtig__: Wir wollen Python 3.7 Graphical Installer (oben).  Das Paket installieren.
 
 ### VS Codium
 

--- a/install/windows.md
+++ b/install/windows.md
@@ -609,7 +609,7 @@ kopierte Installationsdatei für Anaconda befinden (wie im Screenshot hervorgeho
 
 Nachfolgend wird der Befehl
 ```
-bash Anaconda3-2019.03-Linux-x86_64.sh -p ~/.local/anaconda3 -b
+bash Anaconda3-2019.07-Linux-x86_64.sh -p ~/.local/anaconda3 -b
 ```
 verwendet, um die Installation zu starten. **Wichtig** ist zu beachten, dass der zweite Teil des
 Befehls der Name der Installationsdatei ist, sollte dieser sich von dem hier gezeigten unterscheiden


### PR DESCRIPTION
Anpassung in Linux & Windows Installation
Mac -> Python 3.7 (gibt es Gründe für 3.6?)