### PR TITLE
Fix installation instructions (Fixes #75)

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -148,6 +148,12 @@ Git einstellen: im Terminal (<span style="color: red;">__Eigene Daten eintragen!
     $ git config --global user.email "max.mustermann@udo.edu"
     $ git config --global rebase.stat true
     $ git config --global merge.conflictstyle diff3
+ 
+
+Um git beizubringen, VSCodium als Editor zu benutzen:
+
+    $ git config --global core.editor "codium --wait"
+
 
 ### Python
 

--- a/install/macos.md
+++ b/install/macos.md
@@ -62,10 +62,10 @@ __Wichtig__: Wir wollen Python 3.7 Graphical Installer (oben).  Das Paket instal
    Download der Datei `VsCodium-darwin-<VERSION>.zip`.
    Das Programm "VSCodium.app" befindet sich dann in der zip Datei im Downloadordner und muss nach `Programme` verschoben werden. Die App öffnen und mit `Shift+cmd+p` die Kommando Palette öffnen und `Shell Command: Install 'code' command in PATH` ausführen. Nun wird VS Code auch geöffnet, wenn im Terminal "code" eingeben wird.
 
-Um git beizubringen, VS Code zu benutzen, Im Terminal:
+Um git beizubringen, VSCodium zu benutzen, Im Terminal:
 
 ```bash
-git config --global core.editor "code --wait"
+git config --global core.editor "codium --wait"
 ```
 
 - Damit VS Code LaTeX-Code besser darstellen kann, muss das Plugin `LaTeX language support`


### PR DESCRIPTION
Changed the git commit editor command from `code --wait` zu `codium --wait` on macos
and added the setting altogether to the linux instructions (for the new linux users).
