### PR TITLE
New page for instructions for E-Mails at Problems

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -30,5 +30,5 @@
 - title: Archiv
   link: /archive.html
 
-- title: Probleme
+- title: Hilfe
   link: /problem.html

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -30,3 +30,5 @@
 - title: Archiv
   link: /archive.html
 
+- title: Probleme
+  link: /problem.html

--- a/faq/index.md
+++ b/faq/index.md
@@ -5,3 +5,11 @@ category: faq
 ---
 
 Hier listen wir Lösungen für Fragen auf, die besonders häufig gestellt werden.
+
+# Windows
+Am Ende der Installationsanleitung gibt es den Punkt
+*Problembehandlung*, hier sind Lösungsvorschläge für Probleme bei der Installtaion aufgelistet.
+
+# Linux
+Am Ende der Linux-Installationsanleitung gibt es eine Erklärung welche
+Einstellungen für das W-Lan `eduroam` an der TU vorgenommen werden sollten.

--- a/install/linux.md
+++ b/install/linux.md
@@ -12,19 +12,21 @@ Falls man nur am LaTeX-Kurs teilnehmen will, sollte man mindestens Visual Studio
 
 
 <div class="row" style="padding: 10px">
-  <div class="col-md-1" align="center"></div>
   <div class="col-md-4" align="center">
   <a href="#test" class="btn btn-secondary btn-lg btn-block" role="button">
   Testen
   </a>
   </div>
-  <div class="col-md-2" align="center"></div>
   <div class="col-md-4" align="center">
   <a href="#update" class="btn btn-secondary btn-lg btn-block" role="button">
   Aktualisieren
   </a>
   </div>
-  <div class="col-md-1" align="center"></div>
+  <div class="col-md-4" align="center">
+  <a href="#w-lan" class="btn btn-secondary btn-lg btn-block" role="button">
+  W-Lan
+  </a>
+  </div>
 </div>
 
 ## <a id="Installation"></a>Installation
@@ -154,7 +156,7 @@ Git einstellen: im Terminal (<span style="color: red;">__Eigene Daten eintragen!
     $ git config --global user.email "max.mustermann@udo.edu"
     $ git config --global rebase.stat true
     $ git config --global merge.conflictstyle diff3
- 
+
 
 Um git beizubringen, VSCodium als Editor zu benutzen:
 
@@ -241,9 +243,9 @@ Im Terminal:
 
     $ tlmgr update --self --all --reinstall-forcibly-removed
 
-## W-Lan
+## <a id="w-lan"></a>W-Lan
 
-Um das eduroam-Netz an der TU Dortmund einzurichten können folgende Optionen verwendet werden:
+Um das eduroam-Netz an der TU Dortmund einzurichten, können folgende Optionen verwendet werden:
  - Wi-Fi security: WPA- & WPA2-Enterprise
  - Authentication: Geschütztes EAP (PEAP)
  - Anonymous Identity: telesec@tu-dortmund.de
@@ -254,4 +256,3 @@ Um das eduroam-Netz an der TU Dortmund einzurichten können folgende Optionen ve
  - Inner authentication: MSCHAPv2
  - Username: smxxxx@udo.edu
  - Passwort: ******* (W-Lan Passwort)
-

--- a/problem.md
+++ b/problem.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Probleme mit den Programmen oder der Installation?
+---
+
+
+Tritt ein Fehler bei der Installation der Programme auf,
+sollte zuerst geschaut werden, ob der Anleitung gefolgt wurde.
+Unter dem Punkt FAQ gibt es einige Hinweise zu bekannten Fehlern.
+
+Wenn Fehler während des Arbeitens mit den Programmen auftreten,
+sollte erstmal versucht werden selbstständig das Problem zu lösen.
+Hierfür sollte die Fehlermeldung durchgelesen werden, dieses kann schon
+das Problem lösen. Wenn die Fehlermeldung nicht so einfach zu verstehen ist,
+kann nach dem Fehler gesucht werden, wie kann so etwas aussehen:
+- Auskommentieren von Code-Zeilen um den Fehler einzugrenzen
+- Suchen des Fehlers in der Form
+  - Programmname + Fehlermeldung + (Paket)
+
+Sollte dieses nicht helfen, könnt ihr uns eine Mail an
+
+[toolbox-pep-dortmund@googlegroups.com](mailto:toolbox-pep-dortmund@googlegroups.com)
+
+schreiben.
+
+## Welche Informationen benötigen wir?
+In der E-Mail sollten folgende Punkte vorhanden sein:
+- Welches Betriebssystem wird verwendet?
+- Welches Programm gibt eine Fehlermeldung aus?
+- Wie lautet die Fehlermeldung?
+  - Hier hilft der Text oder ein Screenshot.


### PR DESCRIPTION
added a page for E-Mails in case of problems and errors
- added a tab for it in _data
expanded the FAQ-page
added Link to W-Lan in Linux instructions

as discussed in Issue #90 