### PR TITLE
remove link to TeXLive install instructions

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -109,11 +109,11 @@ $ pip install uncertainties
 
 ### TeXLive
 
-- TeXLive: 
+- TeXLive:
     - [Download Link für die aktuellste Version (install-tl-unx.tar.gz)](http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz)
     - __Achtung__ während des Installationsvorgangs werden ca. 5 GiB Dateien heruntergeladen
 
-Im Terminal:
+Es reichen folgende Befehle im Terminal:
 
 ```
 $ cd ~/.local

--- a/install/linux.md
+++ b/install/linux.md
@@ -109,8 +109,8 @@ $ pip install uncertainties
 
 ### TeXLive
 
-- [TeXLive](https://www.tug.org/texlive/): [Installationsanleitung](https://www.tug.org/texlive/quickinstall.html)
-    - [Versionsunabhängiger Link (install-tl-unx.tar.gz)](http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz)
+- TeXLive: 
+    - [Download Link für die aktuellste Version (install-tl-unx.tar.gz)](http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz)
     - __Achtung__ während des Installationsvorgangs werden ca. 5 GiB Dateien heruntergeladen
 
 Im Terminal:


### PR DESCRIPTION
This lead people to the TeXLive installation instructions, which does not install into ~/.local/texlive, so installation fails with permission denied.