### PR TITLE
Delete "start xLauch" in win11 testing phase

### DIFF
--- a/install/windows-11.md
+++ b/install/windows-11.md
@@ -441,7 +441,6 @@ Sollte während des Testens ein Fehler auftreten, kann die [Problembehandlung](#
 
 Um die Python Installation (durch Anaconda) zu testen, sollten alle offenen Fenster der Bash-Kommandozeile
 geschlossen und ein neues geöffnet werden.
-Zusätzlich muss auch das Programm XLaunch über die zuvor angelegte Datei _Praktikum.xlaunch_ gestartet werden.
 
 In die Bash-Kommandozeile werden nun nacheinander die folgenden Befehle eingeben. Nach Eingabe des ersten Befehls
 wird sich das Erscheinungsbild der Kommandozeile etwas verändern.


### PR DESCRIPTION
There is no need to start XLaunch in Win11 since it is not installed. Trying to avoid confusion.