### PR TITLE
Replace Antergos with EndeavourOS

### DIFF
--- a/install/dualboot.md
+++ b/install/dualboot.md
@@ -67,9 +67,9 @@ Support für Updates (LTS Version), 22.04 ist die aktuelle LTS Version.
 
 Alternativen zu Ubuntu sind zum Beispiel (alphabetisch):
 
-* [Antergos](https://antergos.com/)
 * [ArchLinux](https://www.archlinux.org/)
 * [CentOS](https://www.centos.org/)
+* [EndeavourOS](https://endeavouros.com/)
 * [Fedora](https://getfedora.org/de/)
 * [Gentoo](https://www.gentoo.org/)
 * [openSUSE](https://www.opensuse.org/)


### PR DESCRIPTION
In May 2019 Antergos [announced  the discontinuation](https://web.archive.org/web/20190928043707/https://web.archive.org/web/20190824065555/https://antergos.com/blog/antergos-linux-project-ends/) of the development of their distribution. 

This PR replaces Antergos in the dual boot instructions with it's successor [EndeavourOS](https://endeavouros.com/), which had it's initial release in July 2019.