### PR TITLE
Fix table on front page for mobile devices

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,9 +1,3 @@
-/* .container {
-  width: auto;
-  max-width: 80rem;
-  padding: 0 15px;
-} */
-
 html {
   font-size: 1rem;
   }

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,4 +1,4 @@
-
+/* .container {
   width: auto;
   max-width: 80rem;
   padding: 0 15px;
@@ -262,4 +262,11 @@ pre.highlight {
 #backtotop-button.visible a:hover {
   color:            #fff;
   background-color: var(--pep-yellow);
+}
+
+.table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  /* word-break: break-all; */
 }


### PR DESCRIPTION
This lets tables be scrollable horizontally so that there is no horizontal overflow.