### PR TITLE
Mambaforge -> Miniforge3

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -80,16 +80,16 @@ und enthalten Tracking Software. Deswegen empfehlen wir VSCodium, eine Open-Sour
       $ sudo pacman -S code
 
 
-### Python Installation: Mambaforge
+### Python Installation: Miniforge3
 
 Hier müssen im Terminal die folgenden Zeilen eingegeben werden:
 
     $ cd ~/.local
-    $ curl -LO "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-    $ bash Mambaforge-$(uname)-$(uname -m).sh -p ~/.local/mambaforge
+    $ curl -LO "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+    $ bash Miniforge3-$(uname)-$(uname -m).sh -p ~/.local/conda
 
 Die Lizenzvereinbarung muss, je nach Größe des Terminals mit `Enter` bis zum Ende erweitert werden. Und kann mit `yes` akzeptiert werden. Den Ort der Installation haben wir gesetzt, die Abfrage bestätigst du mit `Enter`.
-_Do you wish the installer to initialize Mambaforge by running conda init?_ `yes`.
+_Do you wish the installer to initialize Miniforge3 by running conda init?_ `yes`.
 
 Damit ist die allgemeine Python Umgebung installiert.
 Jetzt muss noch eine spezielle Python Umgebung für den Toolbox Workshop installiert werden.
@@ -103,7 +103,7 @@ Diese startest du mit
 
 Nach erfolgreicher Installation kannst du die Installationsdatei noch löschen
 
-    $ rm ~/.local/Mambaforge-*.sh
+    $ rm ~/.local/Miniforge3-*.sh
 
 ### TeXLive
 
@@ -225,7 +225,7 @@ Es sollte die Dokumentation von TeXLive geöffnet werden (in einem PDF-Betrachte
     $ sudo apt update
     $ sudo apt upgrade
 
-### Python Update: Mambaforge
+### Python Update
 
 Im Terminal:
 

--- a/install/macos.md
+++ b/install/macos.md
@@ -54,23 +54,23 @@ Zur Installation gibst du Folgendes im Terminal ein
 und führst den Befehl mit `Enter` aus.
 Danach "Installieren" auswählen und warten. Der Download wiegt etwa 130 MB.
 
-### Python Installation: Mambaforge
+### Python Installation: Miniforge3
 
 Hier müssen im Terminal die folgenden Zeilen einzeln nacheinander eingegeben werden:
 ```
 cd
 ```
 ```
-curl -LO "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
+curl -LO "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 ```
 ```
-bash Mambaforge-$(uname)-$(uname -m).sh
+bash Miniforge3-$(uname)-$(uname -m).sh
 ```
 
 Die Lizenzvereinbarung muss je nach Größe des Terminals mit `Enter` bis zum Ende erweitert werden.
 Und kann mit `yes` akzeptiert werden.
 Den Ort der Installation kannst du mit `Enter` akzeptieren.
-_Do you wish the installer to initialize Mambaforge by running conda init?_ `yes`.
+_Do you wish the installer to initialize Miniforge3 by running conda init?_ `yes`.
 
 Damit ist die allgemeine Python Umgebung installiert.
 Jetzt muss noch eine spezielle Python Umgebung für den Toolbox Workshop installiert werden.
@@ -86,10 +86,10 @@ Nach erfolgreicher Installation kannst du die Installationsdatei noch löschen. 
 
     ls
 
-im Terminal ein. In der ausgegebenen Liste sollte `Mambaforge-Darwin-arm64.sh`, oder ähnlich, auftauchen.
+im Terminal ein. In der ausgegebenen Liste sollte `Miniforge3-Darwin-arm64.sh`, oder ähnlich, auftauchen.
 Wenn das so ist, kannst du sie mit dem folgenden Befehl löschen
 
-    rm Mambaforge-Darwin-arm64.sh
+    rm Miniforge3-Darwin-arm64.sh
 
 oder dem entsprechenden Dateinamen.
 Falls du dir nicht sicher bist, kannst du uns für diesen Punkt auch im Workshop ansprechen.
@@ -201,7 +201,7 @@ Es sollte die Dokumentation von TeXLive geöffnet werden (in einem PDF-Betrachte
 
 ## <a id="update"></a>Aktualisieren
 
-### Python Update: Mambaforge
+### Python Update
 
 Im Terminal:
 

--- a/install/windows-10.md
+++ b/install/windows-10.md
@@ -24,7 +24,7 @@ am besten kontaktieren kannst.
 Falls du __nicht__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#TeXLive">TeXLive </a> optional.
 Dann kannst du allerdings kein TeX in matplotlib benutzen (führt zu weniger schönen Plots).
 
-Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Miniforge3">Miniforge3: Python Installation</a> optional.
+Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Miniforge3">Python Installation: Miniforge3</a> optional.
 
 Diese Installation verwendet das [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10){:target="_blank"} (WSL),
 um eine Ubuntu Installation verwenden zu können, ohne ein komplett neues Betriebssystem installieren zu müssen.
@@ -343,7 +343,7 @@ mkdir -p ~/.local
 Dieser Befehl erstellt einen Ordner mit dem Namen `.local`, falls dieser nicht schon existiert
 und tut gar nichts, falls dieser Ordner schon existiert.
 
-### <a id="Miniforge3"></a>Miniforge3: Python Installation
+### <a id="Miniforge3"></a>Python Installation: Miniforge3
 
 Für die Installation der Programme, die nötig sind, um die Programmiersprache Python komfortabel
 nutzen zu können, verwenden wir das Tool `mamba`.

--- a/install/windows-10.md
+++ b/install/windows-10.md
@@ -24,7 +24,7 @@ am besten kontaktieren kannst.
 Falls du __nicht__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#TeXLive">TeXLive </a> optional.
 Dann kannst du allerdings kein TeX in matplotlib benutzen (führt zu weniger schönen Plots).
 
-Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Mambaforge">Mambaforge: Python Installation</a> optional.
+Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Miniforge3">Miniforge3: Python Installation</a> optional.
 
 Diese Installation verwendet das [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10){:target="_blank"} (WSL),
 um eine Ubuntu Installation verwenden zu können, ohne ein komplett neues Betriebssystem installieren zu müssen.
@@ -334,7 +334,7 @@ Sicherheit nachgeholt werden.
 
 #### Installationsordner `~/.local`
 
-Für die Installation von [Mambaforge (Python)](#Mambaforge) und [TeXLive (LaTeX)](#TeXLive) wird noch ein Ordner benötigt. Dieser kann mit dem folgenden Befehl erstellt werden.
+Für die Installation von [Miniforge3 (Python)](#Miniforge3) und [TeXLive (LaTeX)](#TeXLive) wird noch ein Ordner benötigt. Dieser kann mit dem folgenden Befehl erstellt werden.
 
 ```
 mkdir -p ~/.local
@@ -343,12 +343,12 @@ mkdir -p ~/.local
 Dieser Befehl erstellt einen Ordner mit dem Namen `.local`, falls dieser nicht schon existiert
 und tut gar nichts, falls dieser Ordner schon existiert.
 
-### <a id="Mambaforge"></a>Mambaforge: Python Installation
+### <a id="Miniforge3"></a>Miniforge3: Python Installation
 
 Für die Installation der Programme, die nötig sind, um die Programmiersprache Python komfortabel
 nutzen zu können, verwenden wir das Tool `mamba`.
 
-Die Installationsdatei _Mambaforge-Linux-x86-64.sh_ kann, durch die Eingabe der folgenden Befehle
+Die Installationsdatei _Miniforge3-Linux-x86-64.sh_ kann, durch die Eingabe der folgenden Befehle
 ins Windows Terminal, heruntergeladen werden:
 
 ```
@@ -358,14 +358,14 @@ Dieser Befehl ändert den aktuellen Pfad auf den Ordner, in den die Installation
 Der aktuelle Pfad wird zwischen dem `:` und `$` angezeigt, dieser sollte nun `~/.local` sein.
 
 ```
-curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
+curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
 ```
 Dieser Befehl lädt die Installationsdatei herunter. Der Download kann einige Zeit in Anspruch nehmen.
 
 ```
 ls
 ```
-Dieser Befehl zeigt alle Dateien an, die sich im aktuellen Pfad befinden. Die Datei _Mambaforge-Linux-x86-64.sh_
+Dieser Befehl zeigt alle Dateien an, die sich im aktuellen Pfad befinden. Die Datei _Miniforge3-Linux-x86-64.sh_
 sollte hier aufgeführt sein.
 
 <img alt="" src="/img/mamba/mamba-download.png" class="screenshot" />
@@ -373,7 +373,7 @@ sollte hier aufgeführt sein.
 Zum Installieren muss der folgende Befehl ausgeführt werden.
 
 ```
-bash Mambaforge-Linux-x86_64.sh -p ~/.local/mambaforge 
+bash Miniforge3-Linux-x86_64.sh -p ~/.local/conda
 ```
 Wie zuvor wird auch dieser Befehl durch Drücken der `Enter`-Taste bestätigt.
 
@@ -433,11 +433,11 @@ angezeigt wird.
 
 <img alt="" src="/img/mamba/mamba-virtual-env-2.png" class="screenshot" />
 
-Nach erfolgreicher Installation kann die Installationsdatei _Mambaforge-Linux-x86-64.sh_
+Nach erfolgreicher Installation kann die Installationsdatei _Miniforge3-Linux-x86-64.sh_
 mit dem Befehl
 
 ```
-rm ~/.local/Mambaforge-Linux-x86_64.sh
+rm ~/.local/Miniforge3-Linux-x86_64.sh
 ```
 gelöscht werden.
 

--- a/install/windows-11.md
+++ b/install/windows-11.md
@@ -24,7 +24,7 @@ am besten kontaktieren kannst.
 Falls du __nicht__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#TeXLive">TeXLive </a> optional.
 Dann kannst du allerdings kein TeX in matplotlib benutzen (führt zu weniger schönen Plots).
 
-Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Mambaforge">Mambaforge: Python Installation</a> optional.
+Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Miniforge3">Miniforge3: Python Installation</a> optional.
 
 Diese Installation verwendet das [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10){:target="_blank"} (WSL),
 um eine Ubuntu Installation verwenden zu können, ohne ein komplett neues Betriebssystem installieren zu müssen.
@@ -289,7 +289,7 @@ Sicherheit nachgeholt werden.
 #### Installationsordner `~/.local`
 
 
-Für die Installation von [Mambaforge (Python)](#Mambaforge) und [TeXLive (LaTeX)](#TeXLive) wird noch ein Ordner benötigt. Dieser kann mit dem folgenden Befehl erstellt werden.
+Für die Installation von [Miniforge3 (Python)](#Miniforge3) und [TeXLive (LaTeX)](#TeXLive) wird noch ein Ordner benötigt. Dieser kann mit dem folgenden Befehl erstellt werden.
 
 ```
 mkdir -p ~/.local
@@ -298,12 +298,12 @@ mkdir -p ~/.local
 Dieser Befehl erstellt einen Ordner mit dem Namen `.local`, falls dieser nicht schon existiert
 und tut gar nichts, falls dieser Ordner schon existiert.
 
-### <a id="Mambaforge"></a>Mambaforge: Python Installation
+### <a id="Miniforge3"></a>Miniforge3: Python Installation
 
 Für die Installation der Programme, die nötig sind, um die Programmiersprache Python komfortabel
 nutzen zu können, verwenden wir das Tool `mamba`.
 
-Die Installationsdatei _Mambaforge-Linux-x86-64.sh_ kann, durch die Eingabe der folgenden Befehle
+Die Installationsdatei _Miniforge3-Linux-x86-64.sh_ kann, durch die Eingabe der folgenden Befehle
 ins Windows Terminal, heruntergeladen werden:
 
 ```
@@ -313,14 +313,14 @@ Dieser Befehl ändert den aktuellen Pfad auf den Ordner, in den die Installation
 Der aktuelle Pfad wird zwischen dem `:` und `$` angezeigt, dieser sollte nun `~/.local` sein.
 
 ```
-curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
+curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
 ```
 Dieser Befehl lädt die Installationsdatei herunter. Der Download kann einige Zeit in Anspruch nehmen.
 
 ```
 ls
 ```
-Dieser Befehl zeigt alle Dateien an, die sich im aktuellen Pfad befinden. Die Datei _Mambaforge-Linux-x86-64.sh_
+Dieser Befehl zeigt alle Dateien an, die sich im aktuellen Pfad befinden. Die Datei _Miniforge3-Linux-x86-64.sh_
 sollte hier aufgeführt sein.
 
 <img alt="" src="/img/mamba/mamba-download.png" class="screenshot" />
@@ -328,7 +328,7 @@ sollte hier aufgeführt sein.
 Zum Installieren muss der folgende Befehl ausgeführt werden.
 
 ```
-bash Mambaforge-Linux-x86_64.sh -p ~/.local/mambaforge 
+bash Miniforge3-Linux-x86_64.sh -p ~/.local/conda
 ```
 Wie zuvor wird auch dieser Befehl durch Drücken der `Enter`-Taste bestätigt.
 
@@ -388,11 +388,11 @@ angezeigt wird.
 
 <img alt="" src="/img/mamba/mamba-virtual-env-2.png" class="screenshot" />
 
-Nach erfolgreicher Installation kann die Installationsdatei _Mambaforge-Linux-x86-64.sh_
+Nach erfolgreicher Installation kann die Installationsdatei _Miniforge3-Linux-x86-64.sh_
 mit dem Befehl
 
 ```
-rm ~/.local/Mambaforge-Linux-x86_64.sh
+rm ~/.local/Miniforge3-Linux-x86_64.sh
 ```
 gelöscht werden.
 

--- a/install/windows-11.md
+++ b/install/windows-11.md
@@ -24,7 +24,7 @@ am besten kontaktieren kannst.
 Falls du __nicht__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#TeXLive">TeXLive </a> optional.
 Dann kannst du allerdings kein TeX in matplotlib benutzen (führt zu weniger schönen Plots).
 
-Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Miniforge3">Miniforge3: Python Installation</a> optional.
+Falls du __nur__ am LaTeX-Kurs teilnehmen willst, ist der Abschnitt <a href="#Miniforge3">Python Installation: Miniforge3</a> optional.
 
 Diese Installation verwendet das [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10){:target="_blank"} (WSL),
 um eine Ubuntu Installation verwenden zu können, ohne ein komplett neues Betriebssystem installieren zu müssen.
@@ -298,7 +298,7 @@ mkdir -p ~/.local
 Dieser Befehl erstellt einen Ordner mit dem Namen `.local`, falls dieser nicht schon existiert
 und tut gar nichts, falls dieser Ordner schon existiert.
 
-### <a id="Miniforge3"></a>Miniforge3: Python Installation
+### <a id="Miniforge3"></a>Python Installation: Miniforge3
 
 Für die Installation der Programme, die nötig sind, um die Programmiersprache Python komfortabel
 nutzen zu können, verwenden wir das Tool `mamba`.


### PR DESCRIPTION
Miniforge3 now includes mamba by default, is identical to Mambaforge and Mambaforge is deprecated, see:https://github.com/conda-forge/miniforge#miniforge-pypy3