### PR TITLE
Hotfix for failing deployment CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: install dependencies


### PR DESCRIPTION
This should bump the ruby version to 3.1.0, thus fixing the version clash with `sass-embedded`.
```
sass-embedded-1.70.0-x86_64-linux requires ruby version >= 3.1.0, which is
incompatible with the current version, 3.0.6
```

We might as well use ruby 3.3.0, though.