### PR TITLE
Fedora texlive fix mentioned in #294

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -91,6 +91,13 @@ Nach erfolgreicher Installation kannst du die Installationsdatei noch löschen
 
 ### TeXLive
 
+- _Nur bei Fedora Distributionen:_  
+Installieren der `Perl` dependencies von `latexmk` mit
+```
+$ sudo dnf install -y $(dnf repoquery --requires --resolve latexmk | grep perl)
+```
+Danach normal fortfahren.
+
 Im Terminal wird mit folgenden drei Befehlen das Installationsskript
 heruntergeladen und ausgeführt.
 ```

--- a/install/linux.md
+++ b/install/linux.md
@@ -34,7 +34,7 @@ jede Eingabe mit einem `sudo` Befehl muss penibel geprüft werden.
 
 - Fedora:
 
-        $ sudo yum install git-core make curl
+        $ sudo dnf install git make curl
 
 - Arch Linux:
 

--- a/install/linux.md
+++ b/install/linux.md
@@ -96,7 +96,7 @@ Installieren der `Perl` dependencies von `latexmk` mit
 ```
 $ sudo dnf install -y $(dnf repoquery --requires --resolve latexmk | grep perl)
 ```
-Danach normal fortfahren.
+Ab hier weiter für alle Linux Distributionen:
 
 Im Terminal wird mit folgenden drei Befehlen das Installationsskript
 heruntergeladen und ausgeführt.


### PR DESCRIPTION
This should fix the `latexmk` `Perl` dependencies for fedora