### PR TITLE
Remove libxcrypt from install instructions for debian/ubuntu OS

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -30,7 +30,7 @@ jede Eingabe mit einem `sudo` Befehl muss penibel geprüft werden.
 
         $ sudo apt update
         $ sudo apt upgrade
-        $ sudo apt install git make curl libxcrypt1
+        $ sudo apt install git make curl
 
 - Fedora:
 

--- a/install/linux.md
+++ b/install/linux.md
@@ -30,7 +30,7 @@ jede Eingabe mit einem `sudo` Befehl muss penibel geprüft werden.
 
         $ sudo apt update
         $ sudo apt upgrade
-        $ sudo apt install git make curl libxcrypt
+        $ sudo apt install git make curl libxcrypt1
 
 - Fedora:
 

--- a/install/windows-10.md
+++ b/install/windows-10.md
@@ -275,7 +275,7 @@ Anschließend kann eine erneute Bestätigung durch Eingabe des Buchstabens `y` u
 Nun können die drei Programme `git`, `make` und `curl` und bereits Abhängigkeiten für `biber` installiert werden. Dies erfolgt durch die Eingabe des
 Befehls
 ```
-sudo apt install git make curl libxcrypt
+sudo apt install git make curl libxcrypt1
 ```
 und anschließende Bestätigung mit der `Enter`-Taste. Auch diese Installation kann wieder etwas Zeit in Anspruch nehmen.
 

--- a/install/windows-10.md
+++ b/install/windows-10.md
@@ -275,7 +275,7 @@ Anschließend kann eine erneute Bestätigung durch Eingabe des Buchstabens `y` u
 Nun können die drei Programme `git`, `make` und `curl` und bereits Abhängigkeiten für `biber` installiert werden. Dies erfolgt durch die Eingabe des
 Befehls
 ```
-sudo apt install git make curl libxcrypt1
+sudo apt install git make curl
 ```
 und anschließende Bestätigung mit der `Enter`-Taste. Auch diese Installation kann wieder etwas Zeit in Anspruch nehmen.
 

--- a/install/windows-11.md
+++ b/install/windows-11.md
@@ -230,7 +230,7 @@ Anschließend kann eine erneute Bestätigung durch Eingabe des Buchstabens `y` u
 Nun können die drei Programme `git`, `make` und `curl` und bereits Abhängigkeiten für `biber` installiert werden. Dies erfolgt durch die Eingabe des
 Befehls
 ```
-sudo apt install git make curl libxcrypt
+sudo apt install git make curl libxcrypt1
 ```
 und anschließende Bestätigung mit der `Enter`-Taste. Auch diese Installation kann wieder etwas Zeit in Anspruch nehmen.
 

--- a/install/windows-11.md
+++ b/install/windows-11.md
@@ -230,7 +230,7 @@ Anschließend kann eine erneute Bestätigung durch Eingabe des Buchstabens `y` u
 Nun können die drei Programme `git`, `make` und `curl` und bereits Abhängigkeiten für `biber` installiert werden. Dies erfolgt durch die Eingabe des
 Befehls
 ```
-sudo apt install git make curl libxcrypt1
+sudo apt install git make curl
 ```
 und anschließende Bestätigung mit der `Enter`-Taste. Auch diese Installation kann wieder etwas Zeit in Anspruch nehmen.
 


### PR DESCRIPTION
~On Ubuntu/Debian-based OS, `libxcrypt` is called `libxcrypt1`. I fixed the package name at the respective locations. The install would otherwise obviously fail.~

`libxcrypt` does not seem to be available on the apt repository... Removed it for now.