### PR TITLE
Add short paragraph on Qt troubleshooting

### DIFF
--- a/install/windows-10.md
+++ b/install/windows-10.md
@@ -668,7 +668,7 @@ qt.qpa.plugin: Could not find the Qt platform "wayland" in ""
 angezeigt wird. Dieser lässt sich mit einer Umgebungsvariablen in der Datei `~/.bashrc`
 beheben. Führe dazu folgenden Befehl im Terminal aus:
 ```
-$ echo 'export QT_QPA_PLATFORM=xcb' >> ~/.bashrc
+echo 'export QT_QPA_PLATFORM=xcb' >> ~/.bashrc
 ```
 
 ### Make

--- a/install/windows-10.md
+++ b/install/windows-10.md
@@ -658,7 +658,18 @@ Mit dem Befehl
 ```
 quit
 ```
-kann das Programm _ipython_ im Anschluss beendet werden
+kann das Programm _ipython_ im Anschluss beendet werden.
+
+
+Beim Ausführen von `%matplotlib` kann es vorkommen, dass der Fehler
+```
+qt.qpa.plugin: Could not find the Qt platform "wayland" in ""
+```
+angezeigt wird. Dieser lässt sich mit einer Umgebungsvariablen in der Datei `~/.bashrc`
+beheben. Führe dazu folgenden Befehl im Terminal aus:
+```
+$ echo 'export QT_QPA_PLATFORM=xcb' >> ~/.bashrc
+```
 
 ### Make
 

--- a/install/windows-11.md
+++ b/install/windows-11.md
@@ -624,7 +624,7 @@ qt.qpa.plugin: Could not find the Qt platform "wayland" in ""
 angezeigt wird. Dieser lässt sich mit einer Umgebungsvariablen in der Datei `~/.bashrc`
 beheben. Führe dazu folgenden Befehl im Terminal aus:
 ```
-$ echo 'export QT_QPA_PLATFORM=xcb' >> ~/.bashrc
+echo 'export QT_QPA_PLATFORM=xcb' >> ~/.bashrc
 ```
 
 ### Make

--- a/install/windows-11.md
+++ b/install/windows-11.md
@@ -614,7 +614,18 @@ Mit dem Befehl
 ```
 quit
 ```
-kann das Programm _ipython_ im Anschluss beendet werden
+kann das Programm _ipython_ im Anschluss beendet werden.
+
+
+Beim Ausführen von `%matplotlib` kann es vorkommen, dass der Fehler
+```
+qt.qpa.plugin: Could not find the Qt platform "wayland" in ""
+```
+angezeigt wird. Dieser lässt sich mit einer Umgebungsvariablen in der Datei `~/.bashrc`
+beheben. Führe dazu folgenden Befehl im Terminal aus:
+```
+$ echo 'export QT_QPA_PLATFORM=xcb' >> ~/.bashrc
+```
 
 ### Make
 


### PR DESCRIPTION
This adds an instruction on how to fix the
```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
```
error that one may encounter when executing `%matplotlib` in an `ipython` shell. I have encountered this several times now on devices using the WSL2.

The fix that worked most of the times is adding
```
export QT_QPA_PLATFORM=xcb
```
to the `.bashrc`/`.zshrc`, thus setting the Qt platform to run on an X11 server.